### PR TITLE
Change instance to world on essentials config path

### DIFF
--- a/docs/mods/suite/Essentials/Configuration.md
+++ b/docs/mods/suite/Essentials/Configuration.md
@@ -4,7 +4,7 @@ title: Configuration
 
 ## Overview
 
-The FTB Essentials configuration file can be found at `<instance>/serverconfig/ftbessentials.snbt`. This contains a configuration section for every command added by the mod; every command can be disabled in the config file, and some commands have extra configuration.
+The FTB Essentials configuration file can be found at `<world>/serverconfig/ftbessentials.snbt`. This contains a configuration section for every command added by the mod; every command can be disabled in the config file, and some commands have extra configuration.
 
 The config file is heavily-commented, so each individual subsection will not be documented here.
 


### PR DESCRIPTION
Changed the word `instance` to `world` which matches the other config docs