### PR TITLE
fix: FTB Essentials `/tpl` should be `/teleport_last` now

### DIFF
--- a/docs/mods/suite/Essentials/Commands.md
+++ b/docs/mods/suite/Essentials/Commands.md
@@ -38,7 +38,7 @@ __Homes__ are player-specific saved teleport destinations. Players may have one 
 |`/back` | N | Teleports you to the last location where you used any command that teleports you (including vanilla `/tp` command). Note that Essentials maintains a teleport history "stack", so this can be used multiple times to go to progressively older teleport points. |
 |`/spawn` | N | Teleports you to the server spawn. |
 |`/rtp` | N | Takes you to a random location in the world with a configured bounds. |
-|`/tpl <player>` | Y | Teleports you to the last known location of the specified player (even if they're currently offline). |
+|`/teleport_last <player>` | Y | Teleports you to the last known location of the specified player (even if they're currently offline). |
 |`/tpx <dimension>` | Y | Teleports you to another dimension at your current location. |
 |`/jump` | Y | Teleports you to the block you're looking at (more precisely, to the top of the block column you're looking at). |
 


### PR DESCRIPTION
According to [FTB-Mods-Issues#1131](https://github.com/FTBTeam/FTB-Mods-Issues/issues/1131#issuecomment-2025493443) and the changelog for the [`2004.1.2 release (MC 1.20.4)`](https://github.com/FTBTeam/FTB-Essentials/releases/tag/v2004.1.2-beta), the `/tpl` command was replaced with the `/teleport_last` command in the `2004.1.1 release (MC 1.20.4)`, although this change was officially noted in the subsequent `2004.1.2` release notes.
 
The changelog excerpt for the `2004.1.2` release states:
> Changed
> - `/tpl` is now `/teleport_last` (Technically this happened last version)
> ...
 
This Pull Request updates the documentation to reflect this change.